### PR TITLE
Changing the Live sample to use Async APIs throughout

### DIFF
--- a/NETCore/Live/MediaV3LiveApp/Program.cs
+++ b/NETCore/Live/MediaV3LiveApp/Program.cs
@@ -63,23 +63,23 @@ namespace LiveSample
         {
 
             IAzureMediaServicesClient client = await CreateMediaServicesClientAsync(config);
-            // Set the polling interval for long running operations to 2 seconds.
-            // The default value is 30 seconds for the .NET client SDK
-            client.LongRunningOperationRetryTimeout = 2;
 
-            try{
-                // CleanupAccount(client, config.ResourceGroup, config.AccountName);
+            // Creating a unique suffix so that we don't have name collisions if you run the sample
+            // multiple times without cleaning up.
+            string uniqueness = Guid.NewGuid().ToString().Substring(0, 13);
+            string liveEventName = "liveevent-" + uniqueness;
+            string assetName = "archiveAsset" + uniqueness;
+            string liveOutputName = "liveOutput" + uniqueness;
+            string streamingLocatorName = "streamingLocator" + uniqueness;
+            string streamingEndpointName = "default";
 
+            try
+            {
                 // Getting the mediaServices account so that we can use the location to create the
                 // LiveEvent and StreamingEndpoint
-                MediaService mediaService = client.Mediaservices.Get(config.ResourceGroup, config.AccountName);
+                MediaService mediaService = await client.Mediaservices.GetAsync(config.ResourceGroup, config.AccountName);
 
-                // Creating a unique suffix so that we don't have name collisions if you run the sample
-                // multiple times without cleaning up.
-                string uniqueness = Guid.NewGuid().ToString().Substring(0, 13);
-                liveEventName = "liveevent-" + uniqueness;
-
-                // <CreateLiveEvent>
+                #region CreateLiveEvent
                 Console.WriteLine($"Creating a live event named {liveEventName}");
                 Console.WriteLine();
 
@@ -87,20 +87,22 @@ namespace LiveSample
                 //      IpV4 address with 4 numbers
                 //      CIDR address range
 
-                // Create the LiveEvent input IP access control  
+                IPRange allAllowIPRange = new IPRange(
+                    name: "AllowAll",
+                    address: "0.0.0.0",
+                    subnetPrefixLength: 0
+                );
+
+                // Create the LiveEvent input IP access control.
                 LiveEventInputAccessControl liveEventInputAccess = new LiveEventInputAccessControl
                 {
-                        Ip = new IPAccessControl(
+                    Ip = new IPAccessControl(
                             allow: new IPRange[]
                             {
-                                new IPRange (
-                                    name: "AllowAll",
-                                    address: "0.0.0.0",
-                                    subnetPrefixLength: 0
-                                )
+                                allAllowIPRange
                             }
                         )
-                
+
                 };
 
                 // Create the LiveEvent Preview IP access control
@@ -110,33 +112,27 @@ namespace LiveSample
                         ip: new IPAccessControl(
                             allow: new IPRange[]
                             {
-                                new IPRange (
-                                    name: "AllowAll",
-                                    address: "0.0.0.0",
-                                    subnetPrefixLength: 0
-                                )
+                                allAllowIPRange
                             }
                         )
                     )
                 };
 
-                
                 // To get the same ingest URL for the same LiveEvent name:
                 // 1. Set vanityUrl to true so you have ingest like: 
                 //        rtmps://liveevent-hevc12-eventgridmediaservice-usw22.channel.media.azure.net:2935/live/522f9b27dd2d4b26aeb9ef8ab96c5c77           
                 // 2. Set accessToken to a desired GUID string (with or without hyphen)
 
-                // The following operation can sometimes take awhile. Be patient.
                 LiveEvent liveEvent = new LiveEvent(
-                    location: mediaService.Location, 
-                    description:"Sample LiveEvent for testing",
-                    vanityUrl:false,
+                    location: mediaService.Location,
+                    description: "Sample LiveEvent for testing",
+                    vanityUrl: false,
                     encoding: new LiveEventEncoding(
                                 // Set this to Standard to enable a transcoding LiveEvent, and None to enable a pass-through LiveEvent
-                                encodingType:LiveEventEncodingType.None, 
-                                presetName:null
+                                encodingType: LiveEventEncodingType.None,
+                                presetName: null
                             ),
-                    input: new LiveEventInput(LiveEventInputProtocol.RTMP,liveEventInputAccess), 
+                    input: new LiveEventInput(LiveEventInputProtocol.RTMP, liveEventInputAccess),
                     preview: liveEventPreview,
                     streamOptions: new List<StreamOptionsFlag?>()
                     {
@@ -150,24 +146,25 @@ namespace LiveSample
                 );
 
                 Console.WriteLine($"Creating the LiveEvent, be patient this can take time...");
-                
+
                 // When autostart is set to true, the Live Event will be started after creation. 
                 // That means, the billing starts as soon as the Live Event starts running. 
                 // You must explicitly call Stop on the Live Event resource to halt further billing.
-                liveEvent = client.LiveEvents.Create(config.ResourceGroup, config.AccountName, liveEventName, liveEvent, autoStart:true);
-                // </CreateLiveEvent>
-                
+                // The following operation can sometimes take awhile. Be patient.
+                liveEvent = await client.LiveEvents.CreateAsync(config.ResourceGroup, config.AccountName, liveEventName, liveEvent, autoStart: true);
+                #endregion
+
                 // Get the input endpoint to configure the on premise encoder with
-                // <GetIngestURL>
+                #region GetIngestUrl
                 string ingestUrl = liveEvent.Input.Endpoints.First().Url;
                 Console.WriteLine($"The ingest url to configure the on premise encoder with is:");
                 Console.WriteLine($"\t{ingestUrl}");
                 Console.WriteLine();
-                // </GetIngestURL>
+                #endregion
 
                 // Use the previewEndpoint to preview and verify
                 // that the input from the encoder is actually being received
-                // <GetPreviewURLs>
+                #region GetPreviewURLs
                 string previewEndpoint = liveEvent.Preview.Endpoints.First().Url;
                 Console.WriteLine($"The preview url is:");
                 Console.WriteLine($"\t{previewEndpoint}");
@@ -176,8 +173,8 @@ namespace LiveSample
                 Console.WriteLine($"Open the live preview in your browser and use the Azure Media Player to monitor the preview playback:");
                 Console.WriteLine($"\thttps://ampdemo.azureedge.net/?url={previewEndpoint}&heuristicprofile=lowlatency");
                 Console.WriteLine();
-                // </GetPreviewURLs>
-                
+                #endregion
+
                 Console.WriteLine("Start the live stream now, sending the input to the ingest url and verify that it is arriving with the preview url.");
                 Console.WriteLine("IMPORTANT TIP!: Make ABSOLUTLEY CERTAIN that the video is flowing to the Preview URL before continuing!");
                 Console.WriteLine("Press enter to continue...");
@@ -185,47 +182,43 @@ namespace LiveSample
                 var ignoredInput = Console.ReadLine();
 
                 // Create an Asset for the LiveOutput to use
-                // <CreateAsset>
-                string assetName = "archiveAsset" + uniqueness;
+                #region CreateAsset
                 Console.WriteLine($"Creating an asset named {assetName}");
                 Console.WriteLine();
-                Asset asset = client.Assets.CreateOrUpdate(config.ResourceGroup, config.AccountName, assetName, new Asset());
-                // </CreateAsset>
-                
+                Asset asset = await client.Assets.CreateOrUpdateAsync(config.ResourceGroup, config.AccountName, assetName, new Asset());
+                #endregion
+
                 // Create the LiveOutput
-                // <CreateLiveOutput>
+                #region CreateLiveOutput
                 string manifestName = "output";
-                string liveOutputName = "liveOutput" + uniqueness;
                 Console.WriteLine($"Creating a live output named {liveOutputName}");
                 Console.WriteLine();
 
                 LiveOutput liveOutput = new LiveOutput(assetName: asset.Name, manifestName: manifestName, archiveWindowLength: TimeSpan.FromMinutes(10));
-                liveOutput = client.LiveOutputs.Create(config.ResourceGroup, config.AccountName, liveEventName, liveOutputName, liveOutput);
-                // </CreateLiveOutput>
-                
-                // Create the StreamingLocator
-                string streamingLocatorName = "streamingLocator" + uniqueness;
+                liveOutput = await client.LiveOutputs.CreateAsync(config.ResourceGroup, config.AccountName, liveEventName, liveOutputName, liveOutput);
+                #endregion
 
+                // Create the StreamingLocator
+                #region CreateStreamingLocator
                 Console.WriteLine($"Creating a streaming locator named {streamingLocatorName}");
                 Console.WriteLine();
 
-                // <CreateStreamingLocator>
                 StreamingLocator locator = new StreamingLocator(assetName: asset.Name, streamingPolicyName: PredefinedStreamingPolicy.ClearStreamingOnly);
-                locator = client.StreamingLocators.Create(config.ResourceGroup, config.AccountName, streamingLocatorName, locator);
+                locator = await client.StreamingLocators.CreateAsync(config.ResourceGroup, config.AccountName, streamingLocatorName, locator);
 
                 // Get the default Streaming Endpoint on the account
-                StreamingEndpoint streamingEndpoint = client.StreamingEndpoints.Get(config.ResourceGroup, config.AccountName, "default");
+                StreamingEndpoint streamingEndpoint = await client.StreamingEndpoints.GetAsync(config.ResourceGroup, config.AccountName, streamingEndpointName);
 
                 // If it's not running, Start it. 
                 if (streamingEndpoint.ResourceState != StreamingEndpointResourceState.Running)
                 {
                     Console.WriteLine("Streaming Endpoint was Stopped, restarting now..");
-                    client.StreamingEndpoints.Start(config.ResourceGroup, config.AccountName, "default");
+                    await client.StreamingEndpoints.StartAsync (config.ResourceGroup, config.AccountName, streamingEndpointName);
                 }
-                // </CreateStreamingLocator>
-                
+                #endregion
+
                 // Get the url to stream the output
-                var paths = client.StreamingLocators.ListPaths(config.ResourceGroup, config.AccountName, streamingLocatorName);
+                var paths = await client.StreamingLocators.ListPathsAsync(config.ResourceGroup, config.AccountName, streamingLocatorName);
 
                 Console.WriteLine("The urls to stream the output from a client:");
                 Console.WriteLine();
@@ -244,11 +237,12 @@ namespace LiveSample
                         stringBuilder.AppendLine($"\t{paths.StreamingPaths[i].StreamingProtocol}-{paths.StreamingPaths[i].EncryptionScheme}");
                         stringBuilder.AppendLine($"\t\t{uriBuilder.ToString()}");
                         stringBuilder.AppendLine();
-                    
-                        if (paths.StreamingPaths[i].StreamingProtocol == StreamingPolicyStreamingProtocol.Dash){
+
+                        if (paths.StreamingPaths[i].StreamingProtocol == StreamingPolicyStreamingProtocol.Dash)
+                        {
                             playerPath = uriBuilder.ToString();
                         }
-                    }                
+                    }
                 }
 
                 if (stringBuilder.Length > 0)
@@ -257,31 +251,24 @@ namespace LiveSample
                     Console.WriteLine("Open the following URL to playback the published,recording LiveOutput in the Azure Media Player");
                     Console.WriteLine($"\t https://ampdemo.azureedge.net/?url={playerPath}&heuristicprofile=lowlatency");
                     Console.WriteLine();
+
+                    Console.WriteLine("Continue experimenting with the stream until you are ready to finish.");
+                    Console.WriteLine("Press enter to stop the LiveOutput...");
+                    Console.Out.Flush();
+                    ignoredInput = Console.ReadLine();
+
+                    await CleanupLiveEventAndOutputAsync(client, config.ResourceGroup, config.AccountName, liveEventName);
+
+                    Console.WriteLine("The LiveOutput and LiveEvent are now deleted.  The event is available as an archive and can still be streamed.");
+                    Console.WriteLine("Press enter to finish cleanup...");
+                    Console.Out.Flush();
+                    ignoredInput = Console.ReadLine();
                 }
                 else
                 {
                     Console.WriteLine("No Streaming Paths were detected.  Has the Stream been started?");
                     Console.WriteLine("Cleaning up and Exiting...");
-
-                    CleanupLiveEventAndOutput(client, config.ResourceGroup, config.AccountName, liveEventName, liveOutputName);
-                    CleanupLocatorAssetAndStreamingEndpoint(client, config.ResourceGroup, config.AccountName, streamingLocatorName, asset.Name);
-
-                    return;
                 }
-
-                Console.WriteLine("Continue experimenting with the stream until you are ready to finish.");
-                Console.WriteLine("Press enter to stop the LiveOutput...");
-                Console.Out.Flush();
-                ignoredInput = Console.ReadLine();
-
-                CleanupLiveEventAndOutput(client, config.ResourceGroup, config.AccountName, liveEventName, liveOutputName);
-
-                Console.WriteLine("The LiveOutput and LiveEvent are now deleted.  The event is available as an archive and can still be streamed.");
-                Console.WriteLine("Press enter to finish cleanup...");
-                Console.Out.Flush();
-                ignoredInput = Console.ReadLine();
-
-                CleanupLocatorAssetAndStreamingEndpoint(client, config.ResourceGroup, config.AccountName, streamingLocatorName, asset.Name);
             }
             catch (ApiErrorException e)
             {
@@ -291,6 +278,256 @@ namespace LiveSample
                 Console.WriteLine();
                 Console.WriteLine("Exiting, cleanup may be necessary...");
                 Console.ReadLine();
+            }
+            finally
+            {
+                await CleanupLiveEventAndOutputAsync(client, config.ResourceGroup, config.AccountName, liveEventName);
+
+                await CleanupLocatorandAssetAsync(client, config.ResourceGroup, config.AccountName, streamingLocatorName, assetName);
+            }
+        }
+
+        private static async Task<LiveEvent> CreateLiveEventAsync(IAzureMediaServicesClient client, string resourceGroup, string accountName, string liveEventName)
+        {
+            // Getting the mediaServices account so that we can use the location to create the
+            // LiveEvent and StreamingEndpoint
+            MediaService mediaService = await client.Mediaservices.GetAsync(resourceGroup, accountName);
+
+            Console.WriteLine($"Creating a live event named {liveEventName}");
+            Console.WriteLine();
+
+            // Note: When creating a LiveEvent, you can specify allowed IP addresses in one of the following formats:                 
+            //      IpV4 address with 4 numbers
+            //      CIDR address range
+
+            IPRange allAllowIPRange = new IPRange(
+                name: "AllowAll",
+                address: "0.0.0.0",
+                subnetPrefixLength: 0
+            );
+
+            // Create the LiveEvent input IP access control.
+            LiveEventInputAccessControl liveEventInputAccess = new LiveEventInputAccessControl
+            {
+                Ip = new IPAccessControl(
+                        allow: new IPRange[]
+                        {
+                                allAllowIPRange
+                        }
+                    )
+
+            };
+
+            // Create the LiveEvent Preview IP access control
+            LiveEventPreview liveEventPreview = new LiveEventPreview
+            {
+                AccessControl = new LiveEventPreviewAccessControl(
+                    ip: new IPAccessControl(
+                        allow: new IPRange[]
+                        {
+                                allAllowIPRange
+                        }
+                    )
+                )
+            };
+
+            // To get the same ingest URL for the same LiveEvent name:
+            // 1. Set vanityUrl to true so you have ingest like: 
+            //        rtmps://liveevent-hevc12-eventgridmediaservice-usw22.channel.media.azure.net:2935/live/522f9b27dd2d4b26aeb9ef8ab96c5c77           
+            // 2. Set accessToken to a desired GUID string (with or without hyphen)
+
+            LiveEvent liveEvent = new LiveEvent(
+                location: mediaService.Location,
+                description: "Sample LiveEvent for testing",
+                vanityUrl: false,
+                encoding: new LiveEventEncoding(
+                            // Set this to Standard to enable a transcoding LiveEvent, and None to enable a pass-through LiveEvent
+                            encodingType: LiveEventEncodingType.None,
+                            presetName: null
+                        ),
+                input: new LiveEventInput(LiveEventInputProtocol.RTMP, liveEventInputAccess),
+                preview: liveEventPreview,
+                streamOptions: new List<StreamOptionsFlag?>()
+                {
+                        // Set this to Default or Low Latency
+                        // When using Low Latency mode, you must configure the Azure Media Player to use the 
+                        // quick start hueristic profile or you won't notice the change. 
+                        // In the AMP player client side JS options, set -  heuristicProfile: "Low Latency Heuristic Profile". 
+                        // To use low latency optimally, you should tune your encoder settings down to 1 second GOP size instead of 2 seconds.
+                        StreamOptionsFlag.LowLatency
+                }
+            );
+
+            Console.WriteLine($"Creating the LiveEvent, be patient this can take time...");
+
+            // When autostart is set to true, the Live Event will be started after creation. 
+            // That means, the billing starts as soon as the Live Event starts running. 
+            // You must explicitly call Stop on the Live Event resource to halt further billing.
+            // The following operation can sometimes take awhile. Be patient.
+            return await client.LiveEvents.CreateAsync(resourceGroup, accountName, liveEventName, liveEvent, autoStart: true);
+        }
+
+        private static async Task<StreamingLocator> CreateAssetAndLocatorAsync(IAzureMediaServicesClient client, string resourceGroup, string accountName, string assetName, string streamingLocatorName)
+        {
+            // Create an Asset for the LiveOutput to use
+            Console.WriteLine($"Creating an asset named {assetName}");
+            Console.WriteLine();
+            Asset asset = await client.Assets.CreateOrUpdateAsync(resourceGroup, accountName, assetName, new Asset());
+
+            // Create the StreamingLocator
+            Console.WriteLine($"Creating a streaming locator named {streamingLocatorName}");
+            Console.WriteLine();
+
+            StreamingLocator locator = new StreamingLocator(assetName: asset.Name, streamingPolicyName: PredefinedStreamingPolicy.ClearStreamingOnly);
+            return await client.StreamingLocators.CreateAsync(resourceGroup, accountName, streamingLocatorName, locator);
+        }
+
+        private static async Task<StreamingEndpoint> StartStreamingEndpointAsync(IAzureMediaServicesClient client, string resourceGroup, string accountName, string assetName, string streamingEndpointName)
+        {
+            // Get the default Streaming Endpoint on the account
+            StreamingEndpoint streamingEndpoint = await client.StreamingEndpoints.GetAsync(resourceGroup, accountName, streamingEndpointName);
+
+            // If it's not running, Start it. 
+            if (streamingEndpoint.ResourceState != StreamingEndpointResourceState.Running)
+            {
+                Console.WriteLine("Streaming Endpoint was Stopped, restarting now..");
+                await client.StreamingEndpoints.StartAsync(resourceGroup, accountName, streamingEndpointName);
+
+                streamingEndpoint = await client.StreamingEndpoints.GetAsync(resourceGroup, accountName, streamingEndpointName);
+            }
+
+            return streamingEndpoint;
+        }
+
+        private static async Task RunAsync2(ConfigWrapper config)
+        {
+            IAzureMediaServicesClient client = await CreateMediaServicesClientAsync(config);
+
+            // Creating a unique suffix so that we don't have name collisions if you run the sample
+            // multiple times without cleaning up.
+            string uniqueness = Guid.NewGuid().ToString().Substring(0, 13);
+            string liveEventName = "liveevent-" + uniqueness;
+            string assetName = "archiveAsset" + uniqueness;
+            string liveOutputName = "liveOutput" + uniqueness;
+            string streamingLocatorName = "streamingLocator" + uniqueness;
+            string streamingEndpointName = "default";
+
+            try
+            {
+                Task<LiveEvent> liveEventTask = CreateLiveEventAsync(client, config.ResourceGroup, config.AccountName, liveEventName);
+                Task<StreamingLocator> streamingLocatorTask = CreateAssetAndLocatorAsync(client, config.ResourceGroup, config.AccountName, assetName, streamingLocatorName);
+                Task<StreamingEndpoint> startStreamingEndpointTask = StartStreamingEndpointAsync(client, config.ResourceGroup, config.AccountName, assetName, streamingEndpointName);
+
+                Task[] tasks = new Task[]
+                {
+                    liveEventTask,
+                    streamingLocatorTask,
+                    startStreamingEndpointTask
+                };
+
+                Task.WaitAll(tasks);
+
+                LiveEvent liveEvent = liveEventTask.Result;
+                StreamingEndpoint streamingEndpoint = startStreamingEndpointTask.Result;
+
+                // Get the input endpoint to configure the on premise encoder with
+                string ingestUrl = liveEvent.Input.Endpoints.First().Url;
+                Console.WriteLine($"The ingest url to configure the on premise encoder with is:");
+                Console.WriteLine($"\t{ingestUrl}");
+                Console.WriteLine();
+
+                // Use the previewEndpoint to preview and verify
+                // that the input from the encoder is actually being received
+                string previewEndpoint = liveEvent.Preview.Endpoints.First().Url;
+                Console.WriteLine($"The preview url is:");
+                Console.WriteLine($"\t{previewEndpoint}");
+                Console.WriteLine();
+
+                Console.WriteLine($"Open the live preview in your browser and use the Azure Media Player to monitor the preview playback:");
+                Console.WriteLine($"\thttps://ampdemo.azureedge.net/?url={previewEndpoint}&heuristicprofile=lowlatency");
+                Console.WriteLine();
+
+                Console.WriteLine("Start the live stream now, sending the input to the ingest url and verify that it is arriving with the preview url.");
+                Console.WriteLine("IMPORTANT TIP!: Make ABSOLUTLEY CERTAIN that the video is flowing to the Preview URL before continuing!");
+                Console.WriteLine("Press enter to continue...");
+                Console.Out.Flush();
+                var ignoredInput = Console.ReadLine();
+
+                // Create the LiveOutput
+                string manifestName = "output";
+                Console.WriteLine($"Creating a live output named {liveOutputName}");
+                Console.WriteLine();
+
+                LiveOutput liveOutput = new LiveOutput(assetName: assetName, manifestName: manifestName, archiveWindowLength: TimeSpan.FromMinutes(10));
+                liveOutput = await client.LiveOutputs.CreateAsync(config.ResourceGroup, config.AccountName, liveEventName, liveOutputName, liveOutput);
+
+                // Get the url to stream the output
+                var paths = await client.StreamingLocators.ListPathsAsync(config.ResourceGroup, config.AccountName, streamingLocatorName);
+
+                Console.WriteLine("The urls to stream the output from a client:");
+                Console.WriteLine();
+                StringBuilder stringBuilder = new StringBuilder();
+                string playerPath = string.Empty;
+
+                for (int i = 0; i < paths.StreamingPaths.Count; i++)
+                {
+                    UriBuilder uriBuilder = new UriBuilder();
+                    uriBuilder.Scheme = "https";
+                    uriBuilder.Host = streamingEndpoint.HostName;
+
+                    if (paths.StreamingPaths[i].Paths.Count > 0)
+                    {
+                        uriBuilder.Path = paths.StreamingPaths[i].Paths[0];
+                        stringBuilder.AppendLine($"\t{paths.StreamingPaths[i].StreamingProtocol}-{paths.StreamingPaths[i].EncryptionScheme}");
+                        stringBuilder.AppendLine($"\t\t{uriBuilder.ToString()}");
+                        stringBuilder.AppendLine();
+
+                        if (paths.StreamingPaths[i].StreamingProtocol == StreamingPolicyStreamingProtocol.Dash)
+                        {
+                            playerPath = uriBuilder.ToString();
+                        }
+                    }
+                }
+
+                if (stringBuilder.Length > 0)
+                {
+                    Console.WriteLine(stringBuilder.ToString());
+                    Console.WriteLine("Open the following URL to playback the published,recording LiveOutput in the Azure Media Player");
+                    Console.WriteLine($"\t https://ampdemo.azureedge.net/?url={playerPath}&heuristicprofile=lowlatency");
+                    Console.WriteLine();
+
+                    Console.WriteLine("Continue experimenting with the stream until you are ready to finish.");
+                    Console.WriteLine("Press enter to stop the LiveOutput...");
+                    Console.Out.Flush();
+                    ignoredInput = Console.ReadLine();
+
+                    await CleanupLiveEventAndOutputAsync(client, config.ResourceGroup, config.AccountName, liveEventName);
+
+                    Console.WriteLine("The LiveOutput and LiveEvent are now deleted.  The event is available as an archive and can still be streamed.");
+                    Console.WriteLine("Press enter to finish cleanup...");
+                    Console.Out.Flush();
+                    ignoredInput = Console.ReadLine();
+                }
+                else
+                {
+                    Console.WriteLine("No Streaming Paths were detected.  Has the Stream been started?");
+                    Console.WriteLine("Cleaning up and Exiting...");
+                }
+            }
+            catch (ApiErrorException e)
+            {
+                Console.WriteLine("Hit ApiErrorException");
+                Console.WriteLine($"\tCode: {e.Body.Error.Code}");
+                Console.WriteLine($"\tCode: {e.Body.Error.Message}");
+                Console.WriteLine();
+                Console.WriteLine("Exiting, cleanup may be necessary...");
+                Console.ReadLine();
+            }
+            finally
+            {
+                await CleanupLiveEventAndOutputAsync(client, config.ResourceGroup, config.AccountName, liveEventName);
+
+                await CleanupLocatorandAssetAsync(client, config.ResourceGroup, config.AccountName, streamingLocatorName, assetName);
             }
         }
 
@@ -337,75 +574,84 @@ namespace LiveSample
         // </CreateMediaServicesClient>
         
         // <CleanupLiveEventAndOutput>
-        private static void CleanupLiveEventAndOutput(IAzureMediaServicesClient client, string resourceGroup, string accountName, string liveEventName, string liveOutputName)
+        private static async Task CleanupLiveEventAndOutputAsync(IAzureMediaServicesClient client, string resourceGroup, string accountName, string liveEventName)
         {
-            // Delete the LiveOutput
-            client.LiveOutputs.Delete(resourceGroup, accountName, liveEventName, liveOutputName);
+            try
+            {
+                LiveEvent liveEvent = await client.LiveEvents.GetAsync(resourceGroup, accountName, liveEventName);
 
-            // Stop and delete the LiveEvent
-            client.LiveEvents.Stop(resourceGroup, accountName, liveEventName);
-            client.LiveEvents.Delete(resourceGroup, accountName, liveEventName);
+                if (liveEvent != null)
+                {
+                    if (liveEvent.ResourceState == LiveEventResourceState.Running)
+                    {
+                        // If the LiveEvent is running, stop it and have it remove any LiveOutputs
+                        await client.LiveEvents.StopAsync(resourceGroup, accountName, liveEventName, removeOutputsOnStop: true);
+                    }
+
+                    // Delete the LiveEvent
+                    await client.LiveEvents.DeleteAsync(resourceGroup, accountName, liveEventName);
+                }
+            }
+            catch (ApiErrorException e)
+            {
+                Console.WriteLine("CleanupLiveEventAndOutputAsync -- Hit ApiErrorException");
+                Console.WriteLine($"\tCode: {e.Body.Error.Code}");
+                Console.WriteLine($"\tCode: {e.Body.Error.Message}");
+                Console.WriteLine();
+            }
         }
         // </CleanupLiveEventAndOutput>
         
         // <CleanupLocatorAssetAndStreamingEndpoint>
-        private static void CleanupLocatorAssetAndStreamingEndpoint(IAzureMediaServicesClient client, string resourceGroup, string accountName, string streamingLocatorName, string assetName)
+        private static async Task CleanupLocatorandAssetAsync(IAzureMediaServicesClient client, string resourceGroup, string accountName, string streamingLocatorName, string assetName)
         {
-            // Delete the Streaming Locator
-            client.StreamingLocators.Delete(resourceGroup, accountName, streamingLocatorName);
-
-            // Delete the Archive Asset
-            client.Assets.Delete(resourceGroup, accountName, assetName);
-
-            // Stop and delete the StreamingEndpoint
-            // client.StreamingEndpoints.Stop(resourceGroup, accountName, endpointName);
-            // client.StreamingEndpoints.Delete(resourceGroup, accountName, endpointName);
-
-        }
-        // </CleanupLocatorAssetAndStreamingEndpoint>
-        
-        // <CleanupAccount>
-        private static void CleanupAccount(IAzureMediaServicesClient client, string resourceGroup, string accountName)
-        {
-            try{
-                
-                Console.WriteLine("Cleaning up the resources used, stopping the LiveEvent. This can take a few minutes to complete.");
-                Console.WriteLine();
-
-                var events = client.LiveEvents.List(resourceGroup, accountName);
-                
-                foreach (LiveEvent l in events)
-                {
-                    if (l.Name == liveEventName){
-                        var outputs = client.LiveOutputs.List(resourceGroup, accountName, l.Name);
-
-                        foreach (LiveOutput o in outputs)
-                        {
-                            client.LiveOutputs.Delete(resourceGroup, accountName, l.Name, o.Name);
-                             Console.WriteLine($"LiveOutput: {o.Name} deleted from LiveEvent {l.Name}. The archived Asset and Streaming URLs are still retained for on-demand viewing.");
-                        }
-
-                        if (l.ResourceState == LiveEventResourceState.Running){
-                            client.LiveEvents.Stop(resourceGroup, accountName, l.Name);
-                            Console.WriteLine($"LiveEvent: {l.Name} Stopped.");
-                            client.LiveEvents.Delete(resourceGroup, accountName, l.Name);
-                            Console.WriteLine($"LiveEvent: {l.Name} Deleted.");
-                            Console.WriteLine();
-                        }
-                    }
-                }
-
-            } 
-            catch(ApiErrorException e)
+            try
             {
-                Console.WriteLine("Hit ApiErrorException");
+                // Delete the Streaming Locator
+                await client.StreamingLocators.DeleteAsync(resourceGroup, accountName, streamingLocatorName);
+
+                // Delete the Archive Asset
+                await client.Assets.DeleteAsync(resourceGroup, accountName, assetName);
+            }
+            catch (ApiErrorException e)
+            {
+                Console.WriteLine("CleanupLocatorandAssetAsync -- Hit ApiErrorException");
                 Console.WriteLine($"\tCode: {e.Body.Error.Code}");
                 Console.WriteLine($"\tCode: {e.Body.Error.Message}");
                 Console.WriteLine();
-
             }
         }
-        // </CleanupAccount>
+        // </CleanupLocatorAssetAndStreamingEndpoint>
+
+        private static async Task CleanupStreamingEndpointAsync(IAzureMediaServicesClient client, string resourceGroup, string accountName, string streamingEndpointName, bool stopEndpoint, bool deleteEndpoint)
+        {
+            try
+            {
+                if (stopEndpoint || deleteEndpoint)
+                {
+                    StreamingEndpoint s = await client.StreamingEndpoints.GetAsync(resourceGroup, accountName, streamingEndpointName);
+
+                    if (s != null && s.ResourceState == StreamingEndpointResourceState.Running)
+                    {
+                        // Stop the StreamingEndpoint
+                        await client.StreamingEndpoints.StopAsync(resourceGroup, accountName, streamingEndpointName);
+                    }
+
+                    if (deleteEndpoint)
+                    {
+                        // Delete the StreamingEndpoint
+                        await client.StreamingEndpoints.DeleteAsync(resourceGroup, accountName, streamingEndpointName);
+                    }
+                }
+            }
+            catch (ApiErrorException e)
+            {
+                Console.WriteLine("CleanupStreamingEndpointAsync -- Hit ApiErrorException");
+                Console.WriteLine($"\tCode: {e.Body.Error.Code}");
+                Console.WriteLine($"\tCode: {e.Body.Error.Message}");
+                Console.WriteLine();
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
We discussed changing the Live Sample to use the XAsync overloads of the SDK client methods.  This changes shows two ways we could do that.  The first method in the RunAsync method replaces the synchronous calls with the XAsync calls but makes no other changes.  Thus instead of calling "LiveEvents.Delete" the code calls "await LiveEvents.DeleteAsync".  I also added a new RunAsync2 method that reorganizes the code a little further and actually runs some of the API calls in parallel (creating the LiveEvent, Starting the StreamingEndpoint, creating the Asset).  This shows the power of the Async APIs and gives a little better idea what can and cannot be done in parallel.  The downside is that this is makes the sample a little more advanced.  I am looking for feedback on which approach we think we want to take and then I will cleanup the sample and add additional comments as necessary.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```
Run the Sample

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->